### PR TITLE
Update cms_plugins.py

### DIFF
--- a/cms_form_plugin/cms_plugins.py
+++ b/cms_form_plugin/cms_plugins.py
@@ -116,10 +116,12 @@ class CMSFormPlugin(CMSPluginBase):
         context['form'] = form
 
         success_url = instance.success_url
-        if not success_url and instance.success_page:
-            success_url = instance.success_page.get_absolute_url(
+        if not success_url:
+            if instance.success_page:
+                success_url = instance.success_page.get_absolute_url(
                 language = get_language_from_request(request)
             )
+
         
         context.update({
             'post_to_url': reverse(


### PR DESCRIPTION
Now this works correctly. The form redirects to success page if no success url is set, but if both are set, it redirects to success url. I think this should be in the documentation.

Just think about your previous code: it had 

> if not success_url and instance.success_page:

it evaluates differently than : 

>  if not (success_url and instance.success_page):

which would be better (this would work if either was set ) but stil would work incorrectly if both success url and success page were set. My proposed solution works in all possible ways: If either settings are set, if none are set and if both are set.
